### PR TITLE
Update kube api resources

### DIFF
--- a/tutorials/kubernetes-demo/manifests/alertmanager.yaml
+++ b/tutorials/kubernetes-demo/manifests/alertmanager.yaml
@@ -12,85 +12,112 @@ spec:
     - ReadWriteOnce
   hostPath:
     path: "/data/pv-alertmanager-0"
----
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: alertmanager
+  creationTimestamp: null
   labels:
     app: alertmanager
+  name: alertmanager
 spec:
-  serviceName: "alertmanager"
+  podManagementPolicy: OrderedReady
   replicas: 1
+  revisionHistoryLimit: 10
   selector:
     matchLabels:
       app: alertmanager
+  serviceName: alertmanager
   template:
     metadata:
+      creationTimestamp: null
       labels:
         app: alertmanager
     spec:
       containers:
-        - name: alertmanager
-          image: "prom/alertmanager:v0.14.0"
-          args:
-            - --config.file=/etc/config/alertmanager.yml
-            - --storage.path=/data
-            - --web.external-url=/
-          ports:
-            - containerPort: 9093
-              name: http
-          readinessProbe:
-            httpGet:
-              path: "/#/status"
-              port: 9093
-            initialDelaySeconds: 30
-            timeoutSeconds: 30
-          volumeMounts:
-            - name: config-volume
-              mountPath: /etc/config
-            - name: alertmanager
-              mountPath: "/data"
-              subPath: ""
-          resources:
-            limits:
-              cpu: 200m
-              memory: 200Mi
-            requests:
-              cpu: 200m
-              memory: 200Mi
-        - name: configmap-reload
-          image: "jimmidyson/configmap-reload:v0.1"
-          args:
-            - --volume-dir=/etc/config
-            - --webhook-url=http://localhost:9093/-/reload
-          volumeMounts:
-            - name: config-volume
-              mountPath: /etc/config
-              readOnly: true
-          resources:
-            limits:
-              cpu: 10m
-              memory: 10Mi
-            requests:
-              cpu: 10m
-              memory: 10Mi
+      - args:
+        - --config.file=/etc/config/alertmanager.yml
+        - --storage.path=/data
+        - --web.external-url=/
+        image: prom/alertmanager:v0.14.0
+        imagePullPolicy: IfNotPresent
+        name: alertmanager
+        ports:
+        - containerPort: 9093
+          name: http
+          protocol: TCP
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /#/status
+            port: 9093
+            scheme: HTTP
+          initialDelaySeconds: 30
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 30
+        resources:
+          limits:
+            cpu: 200m
+            memory: 200Mi
+          requests:
+            cpu: 200m
+            memory: 200Mi
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /etc/config
+          name: config-volume
+        - mountPath: /data
+          name: alertmanager
+      - args:
+        - --volume-dir=/etc/config
+        - --webhook-url=http://localhost:9093/-/reload
+        image: jimmidyson/configmap-reload:v0.1
+        imagePullPolicy: IfNotPresent
+        name: configmap-reload
+        resources:
+          limits:
+            cpu: 10m
+            memory: 10Mi
+          requests:
+            cpu: 10m
+            memory: 10Mi
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /etc/config
+          name: config-volume
+          readOnly: true
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      terminationGracePeriodSeconds: 30
       volumes:
-        - name: config-volume
-          configMap:
-            name: alertmanager
+      - configMap:
+          defaultMode: 420
+          name: alertmanager
+        name: config-volume
+  updateStrategy:
+    type: OnDelete
   volumeClaimTemplates:
   - metadata:
+      creationTimestamp: null
       labels:
         app: alertmanager
       name: alertmanager
     spec:
-      storageClassName: alert-manual
       accessModes:
-        - ReadWriteOnce
+      - ReadWriteOnce
       resources:
         requests:
           storage: 2Gi
+      storageClassName: alert-manual
+      volumeMode: Filesystem
+    status:
+      phase: Pending
+status:
+  replicas: 0
 ---
 apiVersion: v1
 kind: Service

--- a/tutorials/kubernetes-demo/manifests/prometheus-ha-sidecar-lts.yaml
+++ b/tutorials/kubernetes-demo/manifests/prometheus-ha-sidecar-lts.yaml
@@ -64,118 +64,138 @@ spec:
   selector:
     statefulset.kubernetes.io/pod-name: prometheus-1
   type: NodePort
----
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: prometheus
+  creationTimestamp: null
   labels:
     app: prometheus
+  name: prometheus
 spec:
-  serviceName: "prometheus"
+  podManagementPolicy: OrderedReady
   replicas: 2
+  revisionHistoryLimit: 10
   selector:
     matchLabels:
       app: prometheus
+  serviceName: prometheus
   template:
     metadata:
+      creationTimestamp: null
       labels:
         app: prometheus
-        # We will use this label to put all StoreAPis
-        # under the same headless service for
-        # SRV lookup: thanos-store-api.default.svc
         thanos-store-api: "true"
     spec:
+      containers:
+      - args:
+        - --config.file=/etc/prometheus-shared/prometheus.yaml
+        - --storage.tsdb.path=/var/prometheus
+        - --web.enable-lifecycle
+        - --storage.tsdb.retention=2w
+        - --storage.tsdb.min-block-duration=2h
+        - --storage.tsdb.max-block-duration=2h
+        - --web.enable-admin-api
+        image: quay.io/prometheus/prometheus:v2.6.1
+        imagePullPolicy: IfNotPresent
+        name: prometheus
+        ports:
+        - containerPort: 9090
+          name: http-prometheus
+          protocol: TCP
+        resources: {}
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /etc/prometheus-shared
+          name: config-shared
+        - mountPath: /etc/prometheus/rules
+          name: rules
+        - mountPath: /var/prometheus
+          name: prometheus
+      - args:
+        - sidecar
+        - --log.level=debug
+        - --tsdb.path=/var/prometheus
+        - --prometheus.url=http://localhost:9090
+        - --cluster.disable
+        - --reloader.config-file=/etc/prometheus/prometheus.yaml.tmpl
+        - --reloader.config-envsubst-file=/etc/prometheus-shared/prometheus.yaml
+        - |
+          --objstore.config=type: S3
+          config:
+            bucket: demo-bucket
+            access_key: smth
+            secret_key: Need8Chars
+            endpoint: %%S3_ENDPOINT%%
+            insecure: true
+        - --shipper.upload-compacted-once
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.name
+        image: improbable/thanos:v0.3.1
+        imagePullPolicy: IfNotPresent
+        name: thanos
+        ports:
+        - containerPort: 10902
+          name: http-sidecar
+          protocol: TCP
+        - containerPort: 10901
+          name: grpc
+          protocol: TCP
+        resources: {}
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /var/prometheus
+          name: prometheus
+        - mountPath: /etc/prometheus-shared
+          name: config-shared
+        - mountPath: /etc/prometheus
+          name: config
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
       securityContext:
-        runAsUser: 1000
         fsGroup: 2000
         runAsNonRoot: true
+        runAsUser: 1000
+      serviceAccount: prometheus
       serviceAccountName: prometheus
-      containers:
-      - name: prometheus
-        image: quay.io/prometheus/prometheus:v2.6.1
-        args:
-          - --config.file=/etc/prometheus-shared/prometheus.yaml
-          - --storage.tsdb.path=/var/prometheus
-          - --web.enable-lifecycle
-          # TODO: Make retention shorter once all old blocks will be uploaded (!)
-          - --storage.tsdb.retention=2w
-          # Disable compaction.
-          - --storage.tsdb.min-block-duration=2h
-          - --storage.tsdb.max-block-duration=2h
-          - --web.enable-admin-api
-        ports:
-          - name: http-prometheus
-            containerPort: 9090
-        volumeMounts:
-          - name: config-shared
-            mountPath: /etc/prometheus-shared
-          - name: rules
-            mountPath: /etc/prometheus/rules
-          - name: prometheus
-            mountPath: /var/prometheus
-      - name: thanos
-        image: improbable/thanos:v0.3.1
-        args:
-          - sidecar
-          - --log.level=debug
-          - --tsdb.path=/var/prometheus
-          - --prometheus.url=http://localhost:9090
-          - --cluster.disable
-          - --reloader.config-file=/etc/prometheus/prometheus.yaml.tmpl
-          - --reloader.config-envsubst-file=/etc/prometheus-shared/prometheus.yaml
-          # Enable block uploading.
-          - |
-            --objstore.config=type: S3
-            config:
-              bucket: demo-bucket
-              access_key: smth
-              secret_key: Need8Chars
-              endpoint: %%S3_ENDPOINT%%
-              insecure: true
-          # New flag for migrating old blocks.
-          - --shipper.upload-compacted-once
-        env:
-          - name: POD_NAME
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.name
-        ports:
-          - name: http-sidecar
-            containerPort: 10902
-          - name: grpc
-            containerPort: 10901
-        volumeMounts:
-          - name: prometheus
-            mountPath: /var/prometheus
-          - name: config-shared
-            mountPath: /etc/prometheus-shared
-          - name: config
-            mountPath: /etc/prometheus
+      terminationGracePeriodSeconds: 30
       volumes:
-        - name: config
-          configMap:
-            name: prometheus
-        - name: rules
-          configMap:
-            name: prometheus-rules
-        - name: config-shared
-          emptyDir: {}
+      - configMap:
+          defaultMode: 420
+          name: prometheus
+        name: config
+      - configMap:
+          defaultMode: 420
+          name: prometheus-rules
+        name: rules
+      - emptyDir: {}
+        name: config-shared
   updateStrategy:
     type: RollingUpdate
   volumeClaimTemplates:
   - metadata:
+      creationTimestamp: null
       labels:
         app: prometheus
       name: prometheus
     spec:
-      storageClassName: prom-manual
       accessModes:
-        - ReadWriteOnce
+      - ReadWriteOnce
       resources:
         requests:
-          # Normally, probably 15x more (:
           storage: 4Gi
+      storageClassName: prom-manual
+      volumeMode: Filesystem
+    status:
+      phase: Pending
+status:
+  replicas: 0
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/tutorials/kubernetes-demo/manifests/prometheus-ha-sidecar.yaml
+++ b/tutorials/kubernetes-demo/manifests/prometheus-ha-sidecar.yaml
@@ -64,102 +64,126 @@ spec:
   selector:
     statefulset.kubernetes.io/pod-name: prometheus-1
   type: NodePort
----
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: prometheus
+  creationTimestamp: null
   labels:
     app: prometheus
+  name: prometheus
 spec:
-  serviceName: "prometheus"
+  podManagementPolicy: OrderedReady
   replicas: 2
+  revisionHistoryLimit: 10
   selector:
     matchLabels:
       app: prometheus
+  serviceName: prometheus
   template:
     metadata:
+      creationTimestamp: null
       labels:
         app: prometheus
-        # We will use this label to put all StoreAPis
-        # under the same headless service for
-        # SRV lookup: thanos-store-api.default.svc
         thanos-store-api: "true"
     spec:
+      containers:
+      - args:
+        - --config.file=/etc/prometheus-shared/prometheus.yaml
+        - --storage.tsdb.path=/var/prometheus
+        - --web.enable-lifecycle
+        - --storage.tsdb.retention=2w
+        image: quay.io/prometheus/prometheus:v2.6.1
+        imagePullPolicy: IfNotPresent
+        name: prometheus
+        ports:
+        - containerPort: 9090
+          name: http-prometheus
+          protocol: TCP
+        resources: {}
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /etc/prometheus-shared
+          name: config-shared
+        - mountPath: /etc/prometheus/rules
+          name: rules
+        - mountPath: /var/prometheus
+          name: prometheus
+      - args:
+        - sidecar
+        - --log.level=debug
+        - --tsdb.path=/var/prometheus
+        - --prometheus.url=http://localhost:9090
+        - --cluster.disable
+        - --reloader.config-file=/etc/prometheus/prometheus.yaml.tmpl
+        - --reloader.config-envsubst-file=/etc/prometheus-shared/prometheus.yaml
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.name
+        image: improbable/thanos:v0.3.1
+        imagePullPolicy: IfNotPresent
+        name: thanos
+        ports:
+        - containerPort: 10902
+          name: http-sidecar
+          protocol: TCP
+        - containerPort: 10901
+          name: grpc
+          protocol: TCP
+        resources: {}
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /var/prometheus
+          name: prometheus
+        - mountPath: /etc/prometheus-shared
+          name: config-shared
+        - mountPath: /etc/prometheus
+          name: config
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
       securityContext:
-        runAsUser: 1000
         fsGroup: 2000
         runAsNonRoot: true
+        runAsUser: 1000
+      serviceAccount: prometheus
       serviceAccountName: prometheus
-      containers:
-      - name: prometheus
-        image: quay.io/prometheus/prometheus:v2.6.1
-        args:
-          - --config.file=/etc/prometheus-shared/prometheus.yaml
-          - --storage.tsdb.path=/var/prometheus
-          - --web.enable-lifecycle
-          - --storage.tsdb.retention=2w
-        ports:
-          - name: http-prometheus
-            containerPort: 9090
-        volumeMounts:
-          - name: config-shared
-            mountPath: /etc/prometheus-shared
-          - name: rules
-            mountPath: /etc/prometheus/rules
-          - name: prometheus
-            mountPath: /var/prometheus
-      - name: thanos
-        image: improbable/thanos:v0.3.1
-        args:
-          - sidecar
-          - --log.level=debug
-          - --tsdb.path=/var/prometheus
-          - --prometheus.url=http://localhost:9090
-          - --cluster.disable
-          - --reloader.config-file=/etc/prometheus/prometheus.yaml.tmpl
-          - --reloader.config-envsubst-file=/etc/prometheus-shared/prometheus.yaml
-        env:
-          - name: POD_NAME
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.name
-        ports:
-          - name: http-sidecar
-            containerPort: 10902
-          - name: grpc
-            containerPort: 10901
-        volumeMounts:
-          - name: prometheus
-            mountPath: /var/prometheus
-          - name: config-shared
-            mountPath: /etc/prometheus-shared
-          - name: config
-            mountPath: /etc/prometheus
+      terminationGracePeriodSeconds: 30
       volumes:
-        - name: config
-          configMap:
-            name: prometheus
-        - name: rules
-          configMap:
-            name: prometheus-rules
-        - name: config-shared
-          emptyDir: {}
+      - configMap:
+          defaultMode: 420
+          name: prometheus
+        name: config
+      - configMap:
+          defaultMode: 420
+          name: prometheus-rules
+        name: rules
+      - emptyDir: {}
+        name: config-shared
   updateStrategy:
     type: RollingUpdate
   volumeClaimTemplates:
   - metadata:
+      creationTimestamp: null
       labels:
         app: prometheus
       name: prometheus
     spec:
-      storageClassName: prom-manual
       accessModes:
-        - ReadWriteOnce
+      - ReadWriteOnce
       resources:
         requests:
-          # Normally, probably 15x more (:
           storage: 4Gi
+      storageClassName: prom-manual
+      volumeMode: Filesystem
+    status:
+      phase: Pending
+status:
+  replicas: 0
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/tutorials/kubernetes-demo/manifests/prometheus-ha.yaml
+++ b/tutorials/kubernetes-demo/manifests/prometheus-ha.yaml
@@ -30,67 +30,89 @@ spec:
   selector:
     statefulset.kubernetes.io/pod-name: prometheus-1
   type: NodePort
----
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: prometheus
+  creationTimestamp: null
   labels:
     app: prometheus
+  name: prometheus
 spec:
-  serviceName: "prometheus"
+  podManagementPolicy: OrderedReady
   replicas: 2
+  revisionHistoryLimit: 10
   selector:
     matchLabels:
       app: prometheus
+  serviceName: prometheus
   template:
     metadata:
+      creationTimestamp: null
       labels:
         app: prometheus
     spec:
+      containers:
+      - args:
+        - --config.file=/etc/prometheus/prometheus.yaml
+        - --storage.tsdb.path=/var/prometheus
+        - --web.enable-lifecycle
+        - --storage.tsdb.retention=2w
+        image: quay.io/prometheus/prometheus:v2.6.1
+        imagePullPolicy: IfNotPresent
+        name: prometheus
+        ports:
+        - containerPort: 9090
+          name: http-prometheus
+          protocol: TCP
+        resources: {}
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /etc/prometheus
+          name: config
+        - mountPath: /etc/prometheus/rules
+          name: rules
+        - mountPath: /var/prometheus
+          name: prometheus
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
       securityContext:
-        runAsUser: 1000
         fsGroup: 2000
         runAsNonRoot: true
+        runAsUser: 1000
+      serviceAccount: prometheus
       serviceAccountName: prometheus
-      containers:
-      - name: prometheus
-        image: quay.io/prometheus/prometheus:v2.6.1
-        args:
-          - --config.file=/etc/prometheus/prometheus.yaml
-          - --storage.tsdb.path=/var/prometheus
-          - --web.enable-lifecycle
-          - --storage.tsdb.retention=2w
-        ports:
-          - name: http-prometheus
-            containerPort: 9090
-        volumeMounts:
-          - name: config
-            mountPath: /etc/prometheus
-          - name: rules
-            mountPath: /etc/prometheus/rules
-          - name: prometheus
-            mountPath: /var/prometheus
+      terminationGracePeriodSeconds: 30
       volumes:
-        - name: config
-          configMap:
-            name: prometheus
-        - name: rules
-          configMap:
-            name: prometheus-rules
+      - configMap:
+          defaultMode: 420
+          name: prometheus
+        name: config
+      - configMap:
+          defaultMode: 420
+          name: prometheus-rules
+        name: rules
+  updateStrategy:
+    type: OnDelete
   volumeClaimTemplates:
   - metadata:
+      creationTimestamp: null
       labels:
         app: prometheus
       name: prometheus
     spec:
-      storageClassName: prom-manual
       accessModes:
-        - ReadWriteOnce
+      - ReadWriteOnce
       resources:
         requests:
-          # Normally, probably 15x more (:
           storage: 4Gi
+      storageClassName: prom-manual
+      volumeMode: Filesystem
+    status:
+      phase: Pending
+status:
+  replicas: 0
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/tutorials/kubernetes-demo/manifests/prometheus.yaml
+++ b/tutorials/kubernetes-demo/manifests/prometheus.yaml
@@ -13,67 +13,89 @@ spec:
   selector:
     statefulset.kubernetes.io/pod-name: prometheus-0
   type: NodePort
----
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: prometheus
+  creationTimestamp: null
   labels:
     app: prometheus
+  name: prometheus
 spec:
-  serviceName: "prometheus"
+  podManagementPolicy: OrderedReady
   replicas: 1
+  revisionHistoryLimit: 10
   selector:
     matchLabels:
       app: prometheus
+  serviceName: prometheus
   template:
     metadata:
+      creationTimestamp: null
       labels:
         app: prometheus
     spec:
+      containers:
+      - args:
+        - --config.file=/etc/prometheus/prometheus.yaml
+        - --storage.tsdb.path=/var/prometheus
+        - --web.enable-lifecycle
+        - --storage.tsdb.retention=2w
+        image: quay.io/prometheus/prometheus:v2.6.1
+        imagePullPolicy: IfNotPresent
+        name: prometheus
+        ports:
+        - containerPort: 9090
+          name: http-prometheus
+          protocol: TCP
+        resources: {}
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /etc/prometheus
+          name: config
+        - mountPath: /etc/prometheus/rules
+          name: rules
+        - mountPath: /var/prometheus
+          name: prometheus
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
       securityContext:
-        runAsUser: 1000
         fsGroup: 2000
         runAsNonRoot: true
+        runAsUser: 1000
+      serviceAccount: prometheus
       serviceAccountName: prometheus
-      containers:
-      - name: prometheus
-        image: quay.io/prometheus/prometheus:v2.6.1
-        args:
-          - --config.file=/etc/prometheus/prometheus.yaml
-          - --storage.tsdb.path=/var/prometheus
-          - --web.enable-lifecycle
-          - --storage.tsdb.retention=2w
-        ports:
-          - name: http-prometheus
-            containerPort: 9090
-        volumeMounts:
-          - name: config
-            mountPath: /etc/prometheus
-          - name: rules
-            mountPath: /etc/prometheus/rules
-          - name: prometheus
-            mountPath: /var/prometheus
+      terminationGracePeriodSeconds: 30
       volumes:
-        - name: config
-          configMap:
-            name: prometheus
-        - name: rules
-          configMap:
-            name: prometheus-rules
+      - configMap:
+          defaultMode: 420
+          name: prometheus
+        name: config
+      - configMap:
+          defaultMode: 420
+          name: prometheus-rules
+        name: rules
+  updateStrategy:
+    type: OnDelete
   volumeClaimTemplates:
   - metadata:
+      creationTimestamp: null
       labels:
         app: prometheus
       name: prometheus
     spec:
-      storageClassName: prom-manual
       accessModes:
-        - ReadWriteOnce
+      - ReadWriteOnce
       resources:
         requests:
-          # Normally, probably 15x more (:
           storage: 4Gi
+      storageClassName: prom-manual
+      volumeMode: Filesystem
+    status:
+      phase: Pending
+status:
+  replicas: 0
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/tutorials/kubernetes-demo/manifests/thanos-compactor.yaml
+++ b/tutorials/kubernetes-demo/manifests/thanos-compactor.yaml
@@ -1,52 +1,79 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: thanos-compactor
+  creationTimestamp: null
   labels:
     app: thanos-compactor
+  name: thanos-compactor
 spec:
+  podManagementPolicy: OrderedReady
   replicas: 1
+  revisionHistoryLimit: 10
   selector:
     matchLabels:
       app: thanos-compactor
   serviceName: thanos-compactor
   template:
     metadata:
+      creationTimestamp: null
       labels:
         app: thanos-compactor
     spec:
       containers:
-        - name: thanos
-          image: improbable/thanos:v0.3.1
-          args:
-            - compact
-            - --log.level=debug
-            - --data-dir=/data
-            - |
-              --objstore.config=type: S3
-              config:
-                bucket: demo-bucket
-                access_key: smth
-                secret_key: Need8Chars
-                endpoint: %%S3_ENDPOINT%%
-                insecure: true
-            - --sync-delay=30m
-            - --wait
-          ports:
-            - name: http
-              containerPort: 10902
-          livenessProbe:
-            httpGet:
-              port: 10902
-              path: /-/healthy
-          readinessProbe:
-            httpGet:
-              port: 10902
-              path: /-/ready
-          resources:
-            limits:
-              cpu: "1"
-              memory: 1Gi
-            requests:
-              cpu: "1"
-              memory: 1Gi
+      - args:
+        - compact
+        - --log.level=debug
+        - --data-dir=/data
+        - |
+          --objstore.config=type: S3
+          config:
+            bucket: demo-bucket
+            access_key: smth
+            secret_key: Need8Chars
+            endpoint: %%S3_ENDPOINT%%
+            insecure: true
+        - --sync-delay=30m
+        - --wait
+        image: improbable/thanos:v0.3.1
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /-/healthy
+            port: 10902
+            scheme: HTTP
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
+        name: thanos
+        ports:
+        - containerPort: 10902
+          name: http
+          protocol: TCP
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /-/ready
+            port: 10902
+            scheme: HTTP
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
+        resources:
+          limits:
+            cpu: "1"
+            memory: 1Gi
+          requests:
+            cpu: "1"
+            memory: 1Gi
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      terminationGracePeriodSeconds: 30
+  updateStrategy:
+    type: OnDelete
+status:
+  replicas: 0

--- a/tutorials/kubernetes-demo/manifests/thanos-ruler.yaml
+++ b/tutorials/kubernetes-demo/manifests/thanos-ruler.yaml
@@ -24,72 +24,90 @@ data:
         for: 15s # for demo purposes
         labels:
           severity: critical
----
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
+  creationTimestamp: null
   labels:
     app: thanos-ruler
   name: thanos-ruler
 spec:
+  podManagementPolicy: OrderedReady
   replicas: 1
+  revisionHistoryLimit: 10
   selector:
     matchLabels:
       app: thanos-ruler
   serviceName: thanos-ruler
   template:
     metadata:
+      creationTimestamp: null
       labels:
         app: thanos-ruler
         thanos-store-api: "true"
     spec:
       containers:
-        - name: thanos
-          image: improbable/thanos:v0.3.1
-          args:
-            - rule
-            - --log.level=debug
-            - --data-dir=/data
-            - --eval-interval=15s
-            - --cluster.disable
-            - --rule-file=/etc/thanos-ruler/*.rules.yaml
-            - --alertmanagers.url=http://%%ALERTMANAGER_URL%%
-            - --query=thanos-querier.default.svc:9090
-            - |
-              --objstore.config=type: S3
-              config:
-                bucket: demo-bucket
-                access_key: smth
-                secret_key: Need8Chars
-                endpoint: %%S3_ENDPOINT%%
-                insecure: true
-            # We don't want to override underlying metric's cluster label.
-            - --label=ruler_cluster="%%CLUSTER%%"
-            - --label=replica="$(POD_NAME)"
-          env:
-            - name: POD_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.name
-          ports:
-            - name: http
-              containerPort: 10902
-            - name: grpc
-              containerPort: 10901
-          resources:
-            limits:
-              cpu: 500m
-              memory: 500Mi
-            requests:
-              cpu: 500m
-              memory: 500Mi
-          volumeMounts:
-            - mountPath: /etc/thanos-ruler
-              name: config
-      volumes:
-        - configMap:
-            name: thanos-ruler-rules
+      - args:
+        - rule
+        - --log.level=debug
+        - --data-dir=/data
+        - --eval-interval=15s
+        - --cluster.disable
+        - --rule-file=/etc/thanos-ruler/*.rules.yaml
+        - --alertmanagers.url=http://%%ALERTMANAGER_URL%%
+        - --query=thanos-querier.default.svc:9090
+        - |
+          --objstore.config=type: S3
+          config:
+            bucket: demo-bucket
+            access_key: smth
+            secret_key: Need8Chars
+            endpoint: %%S3_ENDPOINT%%
+            insecure: true
+        - --label=ruler_cluster="%%CLUSTER%%"
+        - --label=replica="$(POD_NAME)"
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.name
+        image: improbable/thanos:v0.3.1
+        imagePullPolicy: IfNotPresent
+        name: thanos
+        ports:
+        - containerPort: 10902
+          name: http
+          protocol: TCP
+        - containerPort: 10901
+          name: grpc
+          protocol: TCP
+        resources:
+          limits:
+            cpu: 500m
+            memory: 500Mi
+          requests:
+            cpu: 500m
+            memory: 500Mi
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /etc/thanos-ruler
           name: config
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      terminationGracePeriodSeconds: 30
+      volumes:
+      - configMap:
+          defaultMode: 420
+          name: thanos-ruler-rules
+        name: config
+  updateStrategy:
+    type: OnDelete
+status:
+  replicas: 0
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
Hello there,

In preparation for upgrading to Kubernetes v1.16, (note: we have recently upgraded to v1.13), we have made changes to some of your kubernetes manifests.

The v1.16 release will stop serving a number of deprecated API versions in favor of newer and more stable API versions. For us, this means DaemonSet, Deployment, StatefulSet, and ReplicaSet all need to be updated to be using apps/v1. 

Any manifests referencing deprecated APIs (extensions/v1beta1, apps/v1beta1, or apps/v1beta2) will need to be updated before we roll out Kubernetes v1.16 in order to continue to work.

To lessen the work, we have gone through all the repositories and updated the resource APIs for you. We have pushed any changes to the `machinegun-<randomstring>` branch so feel free to make any changes and/or updates to this branch.

Note: If you are making changes, specifically to Deployments, make sure that you leave the Selector field under the Spec section as this is now mandatory.

During the conversion process, resources may have been updated with defaults and/or changed API fields. The defaults that you see were already in use but are now explicitly set.

Cosmetic changes may have also occurred, for example API fields may have moved around and comments may have been removed. Feel free to move API fields back to their original positions and re-add comments.

We appreciate your assistance in ensuring a smooth transition to Kubernetes v1.16.

If you have any questions, message in #cloud-infrastructure.

Thanks,

Cloud Team